### PR TITLE
Fix null dereference in HTTP parser

### DIFF
--- a/src/httpparse.c
+++ b/src/httpparse.c
@@ -547,14 +547,13 @@ httpparse_content (char* data, int len, HTTP_HEADER_T* headers, int count, char*
        if (headers[i].value && (strcmp(headers[i].key, HTTP_HEADER_KEY_CONTENT_LENGTH) == 0)) {
             if (sscanf(headers[i].value, "%u", (unsigned int*)&length)) {
                 if (*content == 0) {
-                *content = data ;
+                    *content = data ;
                 }
             }
             DBG_MESSAGE_HTTP_PARSE (DBG_MESSAGE_SEVERITY_INFO,
-                "httpparse_content : content length %d", *content_length) ;
-                break ;
+                "httpparse_content : content length %u", length) ;
             break ;
-        }
+       }
     }
 
     if (!chunk_length) {


### PR DESCRIPTION
## Summary
- avoid dereferencing `content_length` when it's NULL

## Testing
- `bash build_and_run.sh` *(fails: unable to clone dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6853ba1651dc8322a2ab03de478e0e10